### PR TITLE
feat: VAUL-2142 add ravencoin address support

### DIFF
--- a/src/blockdata/constants.rs
+++ b/src/blockdata/constants.rs
@@ -64,8 +64,6 @@ pub const LITECOIN_SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 50;
 pub const LITECOIN_PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111;
 /// Test (tesnet, signet, regtest) script address prefix.
 pub const LITECOIN_SCRIPT_ADDRESS_PREFIX_TEST: u8 = 58;
-
-// TODO: review this
 /// Mainnet (stratis) pubkey address prefix.
 pub const STRATIS_PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 75;
 /// Mainnet (stratis) script address prefix.
@@ -74,7 +72,14 @@ pub const STRATIS_SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 125;
 pub const STRATIS_PUBKEY_ADDRESS_PREFIX_TEST: u8 = 120;
 /// Test (tesnet, signet, regtest) script address prefix.
 pub const STRATIS_SCRIPT_ADDRESS_PREFIX_TEST: u8 = 125;
-
+/// Mainnet (ravencoin) pubkey address prefix.
+pub const RAVENCOIN_PUBKEY_ADDRESS_PREFIX_MAIN: u8 = 60; // 0x3c
+/// Mainnet (ravencoin) script address prefix.
+pub const RAVENCOIN_SCRIPT_ADDRESS_PREFIX_MAIN: u8 = 122; // 0x7a
+/// Test (tesnet, signet, regtest) pubkey address prefix.
+pub const RAVENCOIN_PUBKEY_ADDRESS_PREFIX_TEST: u8 = 111; // 0x6f
+/// Test (tesnet, signet, regtest) script address prefix.
+pub const RAVENCOIN_SCRIPT_ADDRESS_PREFIX_TEST: u8 = 196; // 0xc4
 /// The maximum allowed script size.
 pub const MAX_SCRIPT_ELEMENT_SIZE: usize = 520;
 /// How may blocks between halvings.


### PR DESCRIPTION
Ravencoin doesn't support segwit address. The implementation is the same as doge coin.